### PR TITLE
docs(readme): rewrite for clarity, SEO and AI answer engines (EN + ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,96 +1,168 @@
 <!-- hide -->
-# Ejercicios CSS Layouts 
+<div align="center">
 
-Por [@alesanchezr](https://twitter.com/alesanchezr) y [otros colaboradores](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/graphs/contributors) de [4Geeks Academy](http://4geeksacademy.co/)
+# Construye diseños de sitios web con CSS
 
-![last commit](https://img.shields.io/github/last-commit/4geeksacademy/css-layouts-tutorial-exercises)
-[![build by developers](https://img.shields.io/badge/build_by-Developers-blue)](https://breatheco.de)
-[![build by developers](https://img.shields.io/twitter/follow/4geeksacademy?style=social&logo=twitter)](https://twitter.com/4geeksacademy)
+[![Tutorial certificado por 4Geeks](https://img.shields.io/badge/certificado-4Geeks-2563eb)](https://4geeks.com/es/interactive-exercise/css-layouts-tutorial-exercises-es)
+[![Autocorregido con LearnPack](https://img.shields.io/badge/autocorregido-LearnPack-2563eb)](https://github.com/learnpack/learnpack)
+[![Abrir en Codespaces](https://img.shields.io/badge/abrir%20en-Codespaces-fb5a1f?logo=github)](https://codespaces.new/4GeeksAcademy/css-layouts-tutorial-exercises)
 
-¡Hola! Soy [Alejandro Sanchez @alesanchezr](https://github.com/alesanchezr), ¡muy emocionado de tenerte aquí! 🎉 😂 Aprender a programar es difícil, ¡necesitas entrenamiento! [Envíame un DM en Twitter] (https://twitter.com/alesanchezr) si tienes alguna pregunta. 
+</div>
 <!-- endhide -->
 
-## En este tutorial aprenderás los siguientes conceptos:
+Este tutorial interactivo reúne 12 ejercicios de maquetación con CSS, 8 de ellos con corrección automática mediante Jest, con dificultad fácil y una duración estimada de 8 horas. Practicarás `visibility` frente a `display: none`, `position: relative` frente a `absolute`, el `z-index` negativo, `float`, el centrado horizontal con `margin: auto`, barras laterales y columnas con Flexbox, y los pseudoelementos `::before` y `::after`. Sin JavaScript, sin frameworks y sin compilación: solo HTML y CSS.
 
-1. Display vs Position.
-
-2. La propiedad Display: Flex.
-
-3. La propiedad Float.
-
-4. Cómo centrar contenido.
-
-5. Diseños de sidebars.
-
-6. Usar `:before` y `:after`.
 <!-- hide -->
+## 📋 Sobre este tutorial
 
-#### Antes de empezar... hay otros tutoriales relacionados 
-<ol>
-  <li><a href="https://github.com/4GeeksAcademy/html-tutorial-exercises-course">Aprende HTML</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/html-forms-tutorial-exercises">Aprende Formularios HTML</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/css-tutorial-exercises-course">Aprende CSS</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises">Aprende CSS Layouts</a>← 🔥 Estás aquí</li>
-  <li><a href="https://github.com/4GeeksAcademy/bootstrap-exercises-tutorial">Aprender Bootstrap</a></li>
-</ol>
-
-Una completa selección de ejercicios autograduados sobre CSS ¡para cualquier interesado en aprender CSS!
-
-## Instalación en un clic (recomendado)
-
-Puedes empezar estos ejercicios en pocos segundos haciendo clic en: [Abrir en Codespaces](https://codespaces.new/?repo=4GeeksAcademy/css-layouts-tutorial-exercises) (recomendado) o [Abrir en Gitpod](https://gitpod.io#https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises.git).
-
-> Una vez ya tengas abierto VSCode, los ejercicios de LearnPack deberían empezar automáticamente; si esto no sucede puedes intentar empezar los ejercicios escribiendo este comando en tu terminal: `$ learnpack start`
-
-## Instalación manual 
-
-Clona el repositorio en tu ambiente local y sigue los siguientes pasos:
-
-1. Instala LearnPack, el package manager para tutoriales de aprendizaje y el HTML compiler plugin para LearnPack, asegúrate también de tener node.js 14+:
-
-```bash
-$ npm i learnpack -g
-$ learnpack plugins:install learnpack-html
-```
-
-2. Descarga estos ejercicios en particular usando LearnPack y luego `cd` para entrar en la carpeta: 
-
-```bash
-$ learnpack download css-layouts-tutorial-exercises
-$ cd css-layouts-tutorial-exercises
-```
-
-> Nota: Una vez que termines de descargar, encontrarás una carpeta "exercises" que contiene todos los ejercicios.
-
-3. Inicializa el tutorial/ejercicios ejecutando el siguiente comando en el mismo nivel donde se encuentra tu archivo learn.json:
-
-```bash
-$ npm i jest@24.8.0 -g
-$ learnpack start
-```
-
+- **Dificultad**: fácil — el paso siguiente natural después de un curso básico de CSS
+- **Duración**: 8 horas (según declara [`learn.json`](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/learn.json))
+- **Ejercicios**: 12 carpetas dentro de `exercises/` — 1 página de bienvenida y 11 ejercicios prácticos
+- **Corrección**: automática en 8 de ellos, con Jest 29.7.0 y `jest-environment-jsdom`
+- **Tecnologías**: maquetación con CSS, Flexbox, pseudoelementos, HTML
+- **Soluciones de referencia**: 10 ejercicios traen un `solution.hide.css` que puedes destapar si te atascas
+- **Licencia**: el repositorio no incluye ningún fichero `LICENSE`, así que no concede derechos de reutilización ni de redistribución
+- **Idiomas**: [English](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/README.md) · [Español](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/README.es.md)
 <!-- endhide -->
 
-## ¿Cómo están organizados los ejercicios?
+## 🎯 ¿Qué vas a aprender?
 
-Cada ejercicio es una pequeña aplicación de React que contiene los siguientes archivos:
+- **Las dos formas de esconder un elemento**: `visibility: hidden`, que deja el hueco que ocupaba, y `display: none`, que lo saca del flujo y hace que todo lo de abajo suba.
+- **Cambiar el tipo de caja de una etiqueta**: convertir los `<li>` en `inline` para que la lista quede en una sola línea, y convertir `<strong>` en `block` para que un texto en línea pase a ser una caja.
+- **`position: relative` frente a `position: absolute`**: la relativa desplaza el elemento desde donde ya estaba; la absoluta ignora esa posición de partida y lo coloca respecto a su contenedor.
+- **El apilamiento con `z-index`**: cómo un valor negativo manda una imagen posicionada detrás del texto, el "enviar al fondo" de PowerPoint traducido a CSS.
+- **`float`**: pegar una imagen a un lado del documento para que el párrafo la rodee, y usar `margin-right` para que el texto no se le eche encima.
+- **El centrado horizontal con `margin: auto`**: por qué el elemento necesita un `width` declarado antes de que el navegador pueda repartir el espacio sobrante a partes iguales.
+- **Flexbox como herramienta de maquetación**: `display: flex` para poner los hijos en fila, anchos en porcentaje para una barra lateral 30/70 o tres columnas de 33.33%, `flex-direction: column` para apilar bloques y `gap` para separarlos.
+- **Los pseudoelementos `::before` y `::after`**: generar contenido decorativo sin tocar el HTML, dibujar triángulos con bordes transparentes y combinar `position: absolute` con `border-radius` para construir un icono desde cero.
+- **Juntarlo todo**: una página estática completa con un `<header>` a todo el ancho y, debajo, una fila con `<nav>` y `<section>`.
 
-1. **index.html:** tu código HTML va aquí.
-2. **styles.css:** tu código CSS va aquí.
-3. **README.md:** contiene las instrucciones de los ejercicios.
-4. **test.js:** no tienes que abrir este archivo, contiene el script del test para el ejercicio.
+## 👀 ¿Qué vas a construir?
 
-> Nota: Estos ejercicios tienen calificación automática. Los tests son muy rígidos y estrictos, mi recomendación es que no prestes demasiada atención a los tests y los uses solo como una sugerencia o podrías frustrarte.
+Los ejercicios van en orden dentro de `exercises/` y cada uno es una web diminuta que tienes que arreglar o completar:
 
-## Colaboradores
- 
-Gracias a estas personas maravillosas ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
+- **Display y position (del `01` al `04`)**. Después de la página de bienvenida escondes un `<h2>` con `visibility` conservando su hueco y otro con `display: none`, pones en línea los tres `<li>` de `#myUL` y conviertes los `<strong>` en bloques; luego intercambias las clases `.absolutePositionExample` y `.relativePositionExample` sobre el mismo `<div>` para ver la diferencia con tus propios ojos; y después mandas una foto de un gato detrás del texto dándole a `#myImage` un `z-index` negativo.
+- **Float y centrado (`05` y `06`)**. Flotas una imagen junto a un párrafo largo y la separas con un margen, y metes el contenido de la página en un `.myDiv` de 400px de ancho, fondo gris y centrado con `margin: 0 auto`. Aquí el test rechaza a propósito Flexbox, Grid y el truco de `position: absolute` con `translate`: la idea es que domines primero la técnica clásica.
+- **Maquetación con Flexbox (`07`, `08` y `09`)**. Una barra lateral del 30% junto a un área de contenido del 70%, una pantalla partida en tres columnas iguales de exactamente `33.33%`, y un ejercicio de "embellecer" partido del código real de un estudiante: reparas el marcado hasta dejar un `.wrapper` con una `.left-column` que contiene `div1` y `div2` y una `.right-column` con `div3` hasta `div6`, seis etiquetas `<strong>` y fondo rojo en `div1` y `div5`.
+- **Pseudoelementos y maquetación final (`09.1`, `09.2` y `10`)**. Replicas el triángulo azul que ya existe en `h1::before` con otro en `h1::after` que apunta al lado contrario, construyes un icono de calendario cuyas anillas son pseudoelementos posicionados en absoluto y redondeados con `border-radius`, y cierras el tutorial con una página estática donde `.secondWrapper` es una fila flex, la `<section>` ocupa en torno al 80% y un `gap` de 10px separa los bloques, sin `float` ni `position: absolute`.
 
-1. [Alejandro Sanchez (alesanchezr)](https://github.com/alesanchezr), contribución: (codificador) 💻 (idea) 🤔, (build-tests) ⚠️ , (pull-request-review) 🤓 (tutorial de compilación) ✅ (documentación) 📖
+![Resultado del ejercicio de barra lateral: una banda horizontal dividida en dos bloques de la misma altura, a la izquierda una barra gris con el texto Sidebar que ocupa cerca del 30% del ancho y a la derecha un área verde oscuro con el texto Content que ocupa el 70% restante](https://raw.githubusercontent.com/4GeeksAcademy/css-layouts-tutorial-exercises/HEAD/.learn/assets/69N2q6G.png)
 
-2. [Paolo Lucano (plucodev)](https://github.com/plucodev), contribution: (coder), (build-tests)  ⚠️ 
+![Resultado del ejercicio final de maquetación estática: una página azul titulada Static Layout Example con una caja HEADER a todo el ancho bajo el título y, debajo, una columna estrecha NAV a la izquierda junto a un bloque SECTION mucho más ancho a la derecha, separados por un pequeño espacio](https://raw.githubusercontent.com/4GeeksAcademy/css-layouts-tutorial-exercises/HEAD/.learn/assets/0B62fyP.png)
 
-Este proyecto sigue la especificación [all-contributors](https://github.com/kentcdodds/all-contributors). ¡Todas las contribuciones son bienvenidas!
+## 🎓 ¿Qué necesitas antes de empezar?
 
-Este y otros ejercicios son usados para [aprender a programar](https://4geeksacademy.com/es/aprender-a-programar/aprender-a-programar-desde-cero) por parte de los alumnos de 4Geeks Academy [Coding Bootcamp](https://4geeksacademy.com/us/coding-bootcamp) realizado por [Alejandro Sánchez](https://twitter.com/alesanchezr) y muchos otros contribuyentes. Conoce más sobre nuestros [Cursos de Programación](https://4geeksacademy.com/es/curso-de-programacion-desde-cero?lang=es) para convertirte en [Full Stack Developer](https://4geeksacademy.com/es/coding-bootcamps/desarrollador-full-stack/?lang=es), o nuestro [Data Science Bootcamp](https://4geeksacademy.com/es/coding-bootcamps/curso-datascience-machine-learning).
+- **CSS básico es el requisito de verdad**: escribir reglas en una hoja de estilos externa y usar selectores de etiqueta, de clase y de id. Si nunca has escrito una regla CSS, haz antes un tutorial introductorio y vuelve aquí.
+- **HTML básico**: reconocer `<div>`, `<ul>`, `<img>`, `<header>`, `<nav>` y `<section>`, y saber en qué se diferencian `<head>` y `<body>`.
+- **Ni JavaScript, ni React, ni proceso de compilación.** Ocho de los once ejercicios se resuelven tocando solo `styles.css`; solo tres piden modificar el marcado: cambiar una clase en un `<div>`, añadir el contenedor que hay que centrar y reparar la página rota del ejercicio de "embellecer".
+- **En el navegador**: basta con una cuenta de GitHub. El repositorio trae un devcontainer basado en la imagen de Node 22 que instala LearnPack, el plugin de HTML y Jest por ti.
+- **En tu propio ordenador**: Node.js, más `@learnpack/learnpack`, el plugin `@learnpack/html`, `jest@29.7.0` y `jest-environment-jsdom@29.7.0` instalados de forma global.
+- **Tiempo**: 8 horas estimadas repartidas entre 11 ejercicios, unos 40 minutos cada uno.
 
+## ✅ ¿Cómo funciona la corrección automática?
+
+- **8 de las 12 carpetas traen un fichero `test.js`**: `02-Display-none`, `04-Move-image-behind-the-text`, `05-Float-example`, `06-center-content`, `07-Sidebar`, `08-Split-Screen-in-three`, `09-Beautify` y `09.1-Before-and-After`. Las otras cuatro son de leer y experimentar, y dos de ellas lo advierten en sus propias instrucciones.
+- **Los tests corren sobre Jest con el entorno jsdom.** Cada fichero lee tu `index.html` y tu `styles.css` del disco, inyecta el CSS en un documento jsdom y examina el resultado.
+- **Las reglas se buscan por el texto exacto del selector.** El corrector recorre `document.styleSheets[0].cssRules` buscando `selectorText === ".myDiv"` o `"#myUL li"`, así que una regla que funciona en el navegador pero está escrita como `div.myDiv` o `body .myDiv` es invisible para el test.
+- **Los valores se comparan como cadenas de texto.** `33.33%` pasa y `33.3%` no; en el ejercicio de `z-index` la comprobación sí es numérica y vale cualquier valor por debajo de cero.
+- **Casi todos los tests empiezan comprobando que el `<head>` sigue intacto**: el `<meta>`, el `<title>` y el `<link>` que apunta a la hoja de estilos tienen que seguir ahí tal cual venían.
+- **Algunos tests también miran lo que *no* usaste.** El ejercicio de centrado falla si el `body` declara `display: flex`, `display: grid`, `justify-content: center` o `place-items: center`, o si `.myDiv` se centra con `position: absolute` más un `translate`. El de pseudoelementos comprueba que el `h1::before` original conserva su borde derecho `45px solid blue` y su margen inferior de `-35px`.
+
+> 💡 Abre la vista previa antes de escribir nada. Varios ejercicios están pensados para que mires la página de partida, cambies una sola propiedad y vuelvas a mirar: esa comparación es la lección.
+
+## 💡 ¿Qué errores conviene evitar?
+
+- **Escribir los estilos en cualquier sitio que no sea `styles.css`.** Un atributo `style` en línea, o un bloque de CSS escrito dentro del propio documento HTML, puede verse bien en la vista previa, pero el corrector solo lee el fichero de la hoja de estilos.
+- **Tocar el `<head>`.** Quitar el `<title>`, el `<meta>` o cambiar la ruta del `<link>` rompe el primer test de casi todos los ejercicios, y ese test no tiene nada que ver con la propiedad que estabas practicando.
+- **Centrar con Flexbox en el ejercicio de `margin: auto`.** Es el único sitio donde la solución moderna está rechazada a propósito: usa `margin: auto`, `margin: 0 auto` o `margin-left` y `margin-right` en `auto`, sobre un elemento que ya tenga `width: 400px`.
+- **Redondear el ancho de las columnas.** Tres columnas de `33.33%` es lo que espera el test, carácter a carácter.
+- **Tirar de `float` o de `position` en los ejercicios de Flexbox.** La barra lateral, las tres columnas y la maquetación final lo dicen de forma explícita, y esta última pide además usar `gap: 10px` en el contenedor en lugar de ir sumando márgenes.
+- **Reescribir la regla `h1::before` en vez de añadir `h1::after`.** La flecha que ya existe está protegida por el test; lo tuyo es replicarla con `border-left: 45px solid blue` y `margin-left: 20px`.
+- **Esperar que `z-index` funcione sobre un elemento estático.** En ese ejercicio la imagen ya tiene `position: absolute`, que es justo lo que hace que el orden de apilamiento se aplique; sobre un elemento sin posicionar, `z-index` no hace nada.
+- **Confundir `visibility: hidden` con `display: none`.** El primero deja un agujero en la maquetación y el segundo lo cierra. El ejercicio pide uno de cada precisamente para que lo veas.
+
+## ❓ Preguntas frecuentes
+
+### ¿Cuánto se tarda en aprender maquetación CSS con estos ejercicios?
+
+El tutorial declara 8 horas estimadas para 11 ejercicios prácticos, unos 40 minutos cada uno. Quien ya escribe CSS con soltura suele ir más rápido, porque los cuatro primeros ejercicios son experimentos cortos más que construcciones.
+
+### ¿Hace falta saber Flexbox antes de empezar?
+
+No. Flexbox se introduce desde cero en el ejercicio de la barra lateral, donde se explica `display: flex` como la propiedad que coloca a los hijos uno al lado del otro, y a partir de ahí se reutiliza en las tres columnas, en la reparación a dos columnas y en la maquetación estática final.
+
+### ¿Sigue mereciendo la pena aprender `float` y `position` existiendo Flexbox?
+
+Sí, y por eso van primero. `position: absolute` y `z-index` siguen siendo la forma de apilar overlays, insignias y desplegables; `float` sigue siendo cómo el texto rodea una imagen; y `margin: auto` sigue siendo el camino más corto para centrar un bloque de ancho fijo. Flexbox sustituyó a los apaños de maquetación, no a estas propiedades.
+
+### ¿Tengo que instalar algo para empezar?
+
+No. El repositorio incluye un devcontainer, así que abrirlo en GitHub Codespaces te da un editor con LearnPack, su plugin de HTML y Jest ya instalados. La instalación local es opcional y solo necesita Node.js más esos mismos paquetes.
+
+### El diseño se ve bien pero el test sigue fallando, ¿qué hago?
+
+Comprueba tres cosas en este orden: que tu regla esté en `styles.css`, que el selector esté escrito exactamente como lo nombra el enunciado y que el valor coincida al pie de la letra, incluidas la unidad y los decimales. El corrector compara cadenas de texto, así que no tiene ninguna opinión sobre si la página se ve bonita.
+
+### ¿Estos ejercicios son gratis? ¿Puedo reutilizarlos?
+
+Abrirlos y completarlos no cuesta nada, y el CSS que escribas es tuyo. Ahora bien, el repositorio no incluye un fichero `LICENSE`, así que no es open source y no concede permiso para republicar, redistribuir ni vender el material.
+
+<!-- hide -->
+## 📝 Tutoriales relacionados
+
+1. [Aprende HTML](https://github.com/4GeeksAcademy/html-tutorial-exercises-course)
+2. [Aprende formularios HTML](https://github.com/4GeeksAcademy/html-forms-tutorial-exercises)
+3. [Aprende CSS](https://github.com/4GeeksAcademy/css-tutorial-exercises-course)
+4. [Aprende maquetación con CSS](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises) ← 🔥 estás aquí
+5. [Aprende Bootstrap](https://github.com/4GeeksAcademy/bootstrap-exercises-tutorial)
+
+## 🚀 ¿Cómo empezar?
+
+El camino más rápido es [abrirlo en Codespaces](https://codespaces.new/4GeeksAcademy/css-layouts-tutorial-exercises). El devcontainer instala Node 22, LearnPack y Jest por ti, y los ejercicios deberían abrirse solos en cuanto VS Code termine de cargar.
+
+> 💡 Si no arrancan automáticamente, escribe `learnpack start` en la terminal.
+
+También puedes seguir el tutorial online en su [página de ejercicio interactivo](https://4geeks.com/es/interactive-exercise/css-layouts-tutorial-exercises-es).
+
+## 💻 Instalación local
+
+[Clona el repositorio](https://4geeks.com/how-to/github-clone-repository) y, desde la carpeta que contiene `learn.json`:
+
+1. Instala LearnPack, su plugin de HTML y el ejecutor de tests:
+
+    ```bash
+    npm i @learnpack/learnpack -g
+    learnpack plugins:install @learnpack/html
+    npm i jest@29.7.0 jest-environment-jsdom@29.7.0 -g
+    ```
+
+2. Arranca el tutorial:
+
+    ```bash
+    learnpack start
+    ```
+
+## 📚 ¿Cómo están organizados los ejercicios?
+
+Cada ejercicio es una mini web independiente dentro de su propia carpeta:
+
+- **`README.md` / `README.es.md`**: las instrucciones, en inglés y en español.
+- **`index.html`**: el marcado de partida. La mayoría de los ejercicios te piden que no lo cambies.
+- **`styles.css`**: donde va tu CSS.
+- **`test.js`**: el corrector automático, presente en 8 de los ejercicios. No necesitas abrirlo nunca.
+- **`solution.hide.css`** (y `solution.hide.html` en dos ejercicios): la solución de referencia, oculta por la interfaz de LearnPack hasta que la pides.
+
+## 🤝 Colaboradores
+
+20 personas han contribuido a este repositorio. Ordenadas por número de commits:
+
+- [@alesanchezr](https://github.com/alesanchezr) — autor original del tutorial
+- [@josemoracard](https://github.com/josemoracard)
+- [@tommygonzaleza](https://github.com/tommygonzaleza)
+- [@UmiKami](https://github.com/UmiKami)
+- [@Charlytoc](https://github.com/Charlytoc)
+- [@ElviraQDP](https://github.com/ElviraQDP)
+- [@Lorenagubaira](https://github.com/Lorenagubaira)
+
+La lista completa está en el [gráfico de colaboradores](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/graphs/contributors). Este proyecto sigue la especificación [all-contributors](https://github.com/kentcdodds/all-contributors) y las contribuciones de cualquier tipo son bienvenidas: reporta los problemas en el [issue tracker de LearnPack](https://github.com/learnpack/learnpack/issues/new).
+<!-- endhide -->

--- a/README.md
+++ b/README.md
@@ -1,99 +1,168 @@
 <!-- hide -->
-# CSS Layouts Exercises
+<div align="center">
 
-By [@alesanchezr](https://twitter.com/alesanchezr) and [other contributors](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/graphs/contributors) at [4Geeks Academy](http://4geeksacademy.co/)
+# Build Website Layouts with CSS
 
-![last commit](https://img.shields.io/github/last-commit/4geeksacademy/css-layouts-tutorial-exercises)
-[![build by developers](https://img.shields.io/badge/build_by-Developers-blue)](https://breatheco.de)
-[![build by developers](https://img.shields.io/twitter/follow/4geeksacademy?style=social&logo=twitter)](https://twitter.com/4geeksacademy)
+[![Certified 4Geeks tutorial](https://img.shields.io/badge/certified-4Geeks-2563eb)](https://4geeks.com/en/interactive-exercise/css-layouts-tutorial-exercises)
+[![Autograded with LearnPack](https://img.shields.io/badge/autograded-LearnPack-2563eb)](https://github.com/learnpack/learnpack)
+[![Open in Codespaces](https://img.shields.io/badge/open%20in-Codespaces-fb5a1f?logo=github)](https://codespaces.new/4GeeksAcademy/css-layouts-tutorial-exercises)
 
-Hi! I'm [Alejandro Sanchez @alesanchezr](https://github.com/alesanchezr), really excited to have you here! 🎉 😂 Learning to code is hard, you need coaching! [DM me on twitter](https://twitter.com/alesanchezr) if you have any questions. 
-
-*Estas instrucciones [están disponibles en 🇪🇸 español](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/master/README.es.md) :es:*
+</div>
 <!-- endhide -->
 
-## You'll be learning the following concepts:
-
-1. Display vs Position.
-
-2. Display: Flex property.
-
-3. Float property.
-
-4. How to center content.
-
-5. Sidebar layouts.
-
-6. Using `:before` and `:after`.
+This interactive tutorial contains 12 CSS layout exercises, 8 of them auto-graded by Jest, rated easy and budgeted at 8 hours. You practice `visibility` versus `display: none`, `position: relative` versus `absolute`, negative `z-index`, `float`, horizontal centering with `margin: auto`, Flexbox sidebars and three-column splits, and the `::before` / `::after` pseudo-elements. No JavaScript, no framework and no build step: you edit HTML and CSS only.
 
 <!-- hide -->
-#### Before we start... other related tutorials</h4>
-<ol>
-  <li><a href="https://github.com/4GeeksAcademy/html-tutorial-exercises-course">Learn HTML</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/html-forms-tutorial-exercises">Learn HTML Forms</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/css-tutorial-exercises-course">Learn CSS</a></li>
-  <li><a href="https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises">Learn CSS Layouts</a>← 🔥 You are here now</li>
-  <li><a href="https://github.com/4GeeksAcademy/bootstrap-exercises-tutorial">Learn Bootstrap</a></li>
-</ol>
-Complete selection of autograded CSS exercises, for anyone interested in learning CSS!
+## 📋 About this tutorial
 
-## One click installation (recommended):
-
-You can open these exercises in just a few seconds by clicking: [Open in Codespaces](https://codespaces.new/?repo=4GeeksAcademy/css-layouts-tutorial-exercises) (recommended) or [Open in Gitpod](https://gitpod.io#https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises.git).
-
-> Once you have VSCode open the LearnPack exercises should start automatically. If exercises don't run automatically you can try typing on your terminal: `$ learnpack start`
-
-## Local installation
-
-[Clone the repository](https://4geeks.com/how-to/github-clone-repository) in your local environment and follow the steps below:
-
-1. Install LearnPack, the package manager for learning tutorials and the HTML compiler plugin for LearnPack, make sure you also have node.js 14+:
-
-```bash
-$ npm i learnpack -g
-$ learnpack plugins:install learnpack-html
-```
-
-2. Download these particular exercises using LearnPack and `cd` into the folder:
-
-```bash
-$ learnpack download css-layouts-tutorial-exercises
-$ cd css-layouts-tutorial-exercises
-```
-
-> Note: Once you finish downloading, you will find an "exercises" folder that contains all the exercises within.
-
-3. Start the tutorial/exercises by running the following command at the same level where your learn.json file is:
-
-```bash
-$ npm i jest@24.8.0 -g
-$ learnpack start
-```
-
+- **Difficulty**: Easy — the natural next step after a basic CSS course
+- **Duration**: 8 hours (as declared in [`learn.json`](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/learn.json))
+- **Exercises**: 12 folders inside `exercises/` — 1 welcome page and 11 hands-on exercises
+- **Grading**: automatic in 8 of them, with Jest 29.7.0 and `jest-environment-jsdom`
+- **Technologies**: CSS layout, Flexbox, pseudo-elements, HTML
+- **Reference solutions**: 10 exercises ship a hidden `solution.hide.css` you can reveal when stuck
+- **License**: the repository ships no `LICENSE` file, so no reuse or redistribution rights are granted
+- **Languages**: [English](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/README.md) · [Español](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/blob/HEAD/README.es.md)
 <!-- endhide -->
 
-## How are the exercises organized?
+## 🎯 What will you learn?
 
-Each exercise is a small React application containing the following files:
+- **The two ways to hide an element**: `visibility: hidden`, which keeps the space the element occupied, versus `display: none`, which removes it from the flow so everything below moves up.
+- **Changing the box type of a tag**: turning `<li>` elements into `inline` so a list runs across one line, and turning `<strong>` into `block` so inline text becomes a box.
+- **`position: relative` versus `position: absolute`**: relative offsets an element from where it already was, absolute ignores that starting point and positions it against its containing block.
+- **Stacking with `z-index`**: how a negative value pushes a positioned image behind the text, PowerPoint's "send to back" translated to CSS.
+- **`float`**: pulling an image to one side of the document so the paragraph wraps around it, and using `margin-right` to keep the text from touching it.
+- **Horizontal centering with `margin: auto`**: why an element needs a declared `width` before the browser can split the leftover space evenly on both sides.
+- **Flexbox as a layout tool**: `display: flex` to place children in a row, percentage widths for a 30/70 sidebar or three 33.33% columns, `flex-direction: column` for stacked blocks, and `gap` for the spacing between them.
+- **Pseudo-elements `::before` and `::after`**: generating decorative content without touching the HTML, drawing triangles out of transparent borders, and using `position: absolute` plus `border-radius` to build an icon from scratch.
+- **Putting it together**: a complete static page with a full-width `<header>` and a `<nav>` + `<section>` row underneath.
 
-1. **index.html:** your HTML code goes here.
-2. **styles.css:** your CSS code goes here.
-3. **README.md:** contains exercise instructions.
-4. **test.js:** you don't have to open this file, it contains the testing script for the exercise.
+## 👀 What will you build?
 
-> Note: The exercises have automatic grading, but it's very rigid and strict, my recommendation is to not take the tests too serious and use them only as a suggestion, or you may get frustrated.
+The exercises run in order inside `exercises/` and each one is a tiny website you fix or complete:
 
-## Contributors
+- **Display and position (`01` to `04`)**. After the welcome page you hide one `<h2>` with `visibility` while keeping its space and a second one with `display: none`, spread the three `<li>` of `#myUL` inline and turn `<strong>` into blocks; then you swap the `.absolutePositionExample` and `.relativePositionExample` classes on the same `<div>` to see the difference with your own eyes; then you send a photo of a cat behind the text by giving `#myImage` a negative `z-index`.
+- **Float and centering (`05` and `06`)**. You float an image next to a long paragraph and separate it with a margin, and you wrap the page content in a `.myDiv` that is 400px wide, gray, and centered with `margin: 0 auto` — the test explicitly rejects Flexbox, Grid and the absolute-plus-translate trick here, because the point is to master the classic technique first.
+- **Flexbox layouts (`07`, `08` and `09`)**. A 30% sidebar next to a 70% content area, a screen split into three equal columns of exactly `33.33%`, and a "beautify" exercise built from a real student's broken code: you repair the markup into a `.wrapper` with a `.left-column` holding `div1` and `div2` and a `.right-column` holding `div3` through `div6`, six `<strong>` labels, and red backgrounds on `div1` and `div5`.
+- **Pseudo-elements and the final layout (`09.1`, `09.2` and `10`)**. You mirror an existing `h1::before` blue triangle with an `h1::after` one that points the other way, build a calendar icon whose rings are absolutely positioned pseudo-elements rounded with `border-radius`, and close the tutorial with a static page where `.secondWrapper` is a flex row, `<section>` takes about 80% and a 10px gap separates the blocks — no `float`, no `position: absolute`.
 
-Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
+![Result of the sidebar exercise: a horizontal band split into two blocks of the same height, a gray sidebar labelled Sidebar taking about 30% of the width on the left, and a dark green area labelled Content taking the remaining 70% on the right](https://raw.githubusercontent.com/4GeeksAcademy/css-layouts-tutorial-exercises/HEAD/.learn/assets/69N2q6G.png)
 
-1. [Alejandro Sanchez (alesanchezr)](https://github.com/alesanchezr), contribution: (coder)  💻 (idea) 🤔, (build-tests) ⚠️ , (pull-request-review) 🤓 
-(build-tutorial) ✅  (documentation) 📖
+![Result of the final static layout exercise: a blue page titled Static Layout Example with a full-width HEADER box under the title, and below it a narrow NAV column on the left next to a much wider SECTION block on the right, separated by a small gap](https://raw.githubusercontent.com/4GeeksAcademy/css-layouts-tutorial-exercises/HEAD/.learn/assets/0B62fyP.png)
 
-2. [Paolo Lucano (plucodev)](https://github.com/plucodev), contribution: (coder), (build-tests)  ⚠️ 
+## 🎓 What do you need before starting?
 
-This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind are welcome!
+- **Basic CSS is the real prerequisite**: writing rules in an external stylesheet, and using tag, class and id selectors. If you have never written a CSS rule, do an introductory CSS tutorial first and come back here.
+- **Basic HTML**: recognising `<div>`, `<ul>`, `<img>`, `<header>`, `<nav>` and `<section>`, and knowing the difference between `<head>` and `<body>`.
+- **No JavaScript, no React and no build step.** Eight of the eleven exercises are solved by editing `styles.css` alone; only three touch the markup: swapping a class on a `<div>`, adding the container you have to center, and repairing the broken "beautify" page.
+- **In the browser**: a GitHub account is enough. The repository ships a devcontainer based on the Node 22 image that installs LearnPack, the HTML plugin and Jest for you.
+- **On your own machine**: Node.js, plus `@learnpack/learnpack`, the `@learnpack/html` plugin, `jest@29.7.0` and `jest-environment-jsdom@29.7.0` installed globally.
+- **Time**: 8 estimated hours across 11 exercises, roughly 40 minutes each.
+
+## ✅ How does the automatic grading work?
+
+- **8 of the 12 folders ship a `test.js` file**: `02-Display-none`, `04-Move-image-behind-the-text`, `05-Float-example`, `06-center-content`, `07-Sidebar`, `08-Split-Screen-in-three`, `09-Beautify` and `09.1-Before-and-After`. The other four are read-and-experiment exercises, and two of them say so in their own instructions.
+- **The tests run on Jest with the jsdom environment.** Each file reads your `index.html` and your `styles.css` from disk, injects the CSS into a jsdom document and inspects the result.
+- **Rules are matched by exact selector text.** The grader loops over `document.styleSheets[0].cssRules` looking for `selectorText === ".myDiv"` or `"#myUL li"`, so a rule that works in the browser but is written as `div.myDiv` or `body .myDiv` is invisible to the test.
+- **Values are compared as strings.** `33.33%` passes and `33.3%` does not; in the `z-index` exercise the check is numeric instead, and any value below zero is accepted.
+- **Almost every test starts by verifying the `<head>` is intact**: the `<meta>`, the `<title>` and the `<link>` pointing at the stylesheet must still be there, exactly as they came.
+- **Some tests also check what you did *not* use.** The centering exercise fails if `body` declares `display: flex`, `display: grid`, `justify-content: center` or `place-items: center`, or if `.myDiv` is centered with `position: absolute` plus a `translate`. The pseudo-element exercise asserts that the original `h1::before` still has its `45px solid blue` right border and its `-35px` bottom margin.
+
+> 💡 Open the preview before writing anything. Several exercises are designed so that you look at the starting page, change one property and look again — that comparison is the lesson.
+
+## 💡 What mistakes should you avoid?
+
+- **Writing your styles anywhere other than `styles.css`.** An inline `style` attribute, or a block of CSS written inside the HTML document itself, may look correct in the preview, but the grader only reads the stylesheet file.
+- **Touching the `<head>`.** Removing the `<title>`, the `<meta>` or renaming the path in the `<link>` breaks the first test of nearly every exercise, and that test has nothing to do with the property you were practising.
+- **Centering with Flexbox in the `margin: auto` exercise.** It is the one place where the modern solution is deliberately rejected: use `margin: auto`, `margin: 0 auto` or `margin-left`/`margin-right` set to `auto`, on an element that already has `width: 400px`.
+- **Rounding the column widths.** Three columns of `33.33%` is what the test expects, character for character.
+- **Reaching for `float` or `position` in the Flexbox exercises.** The sidebar, the three-column split and the final static layout all state it explicitly, and the last one asks you to use `gap: 10px` on the container instead of stacking margins.
+- **Rewriting the `h1::before` rule instead of adding `h1::after`.** The arrow that already exists is protected by the test; your job is to mirror it with `border-left: 45px solid blue` and `margin-left: 20px`.
+- **Expecting `z-index` to work on a static element.** In that exercise the image is already `position: absolute`, which is what makes the stacking order apply; on an unpositioned element `z-index` does nothing.
+- **Forgetting that `visibility: hidden` and `display: none` are not interchangeable.** The first one leaves a hole in the layout, the second one closes it. The exercise asks for one of each precisely so you can see it.
+
+## ❓ Frequently asked questions
+
+### How long does it take to learn CSS layouts with these exercises?
+
+The tutorial declares 8 hours of estimated work for 11 hands-on exercises, around 40 minutes each. Someone who already writes CSS comfortably usually goes faster, because the first four exercises are short experiments rather than builds.
+
+### Do I need to know Flexbox before starting?
+
+No. Flexbox is introduced from scratch in the sidebar exercise, where `display: flex` is explained as the property that places children side by side, and then reused for the three-column split, the two-column "beautify" repair and the final static layout.
+
+### Should I still learn `float` and `position` if Flexbox exists?
+
+Yes, and that is why they come first here. `position: absolute` and `z-index` are still how overlays, badges and dropdowns are stacked, `float` is still how text wraps around an image, and `margin: auto` is still the shortest way to center a fixed-width block. Flexbox replaced the layout hacks, not these properties.
+
+### Do I have to install anything to start?
+
+No. The repository includes a devcontainer, so opening it in GitHub Codespaces gives you an editor with LearnPack, its HTML plugin and Jest already installed. Local installation is optional and only needs Node.js plus those same packages.
+
+### My layout looks right but the test still fails — what now?
+
+Check three things in this order: that your rule lives in `styles.css`, that the selector is written exactly as the instruction names it, and that the value matches literally, including the unit and the decimals. The grader compares strings, so it has no opinion about whether the page looks good.
+
+### Are these exercises free, and can I reuse them?
+
+Opening and completing them costs nothing, and the CSS you write is yours. The repository does not include a `LICENSE` file, though, so it is not open source and no permission to republish, redistribute or resell the material is granted.
 
 <!-- hide -->
-This and many other exercises are built by students as part of the 4Geeks Academy [Coding Bootcamp](https://4geeksacademy.com/us/coding-bootcamp) by [Alejandro Sánchez](https://twitter.com/alesanchezr) and many other contributors. Find out more about our [Full Stack Developer Course](https://4geeksacademy.com/us/coding-bootcamps/part-time-full-stack-developer), and  [Data Science Bootcamp](https://4geeksacademy.com/us/coding-bootcamps/datascience-machine-learning).
+## 📝 Related tutorials
+
+1. [Learn HTML](https://github.com/4GeeksAcademy/html-tutorial-exercises-course)
+2. [Learn HTML Forms](https://github.com/4GeeksAcademy/html-forms-tutorial-exercises)
+3. [Learn CSS](https://github.com/4GeeksAcademy/css-tutorial-exercises-course)
+4. [Learn CSS Layouts](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises) ← 🔥 you are here
+5. [Learn Bootstrap](https://github.com/4GeeksAcademy/bootstrap-exercises-tutorial)
+
+## 🚀 How to start
+
+The fastest path is [Open in Codespaces](https://codespaces.new/4GeeksAcademy/css-layouts-tutorial-exercises). The devcontainer installs Node 22, LearnPack and Jest for you, and the exercises should open on their own once VS Code finishes loading.
+
+> 💡 If they do not start automatically, run `learnpack start` in the terminal.
+
+You can also follow the tutorial online on its [interactive exercise page](https://4geeks.com/en/interactive-exercise/css-layouts-tutorial-exercises).
+
+## 💻 Local installation
+
+[Clone the repository](https://4geeks.com/how-to/github-clone-repository) and then, from the folder that contains `learn.json`:
+
+1. Install LearnPack, its HTML plugin and the test runner:
+
+    ```bash
+    npm i @learnpack/learnpack -g
+    learnpack plugins:install @learnpack/html
+    npm i jest@29.7.0 jest-environment-jsdom@29.7.0 -g
+    ```
+
+2. Start the tutorial:
+
+    ```bash
+    learnpack start
+    ```
+
+## 📚 How the exercises are organized
+
+Every exercise is a self-contained mini website inside its own folder:
+
+- **`README.md` / `README.es.md`**: the instructions, in English and Spanish.
+- **`index.html`**: the starting markup. Most exercises ask you not to change it.
+- **`styles.css`**: where your CSS goes.
+- **`test.js`**: the automatic grader, present in 8 of the exercises. You never need to open it.
+- **`solution.hide.css`** (and `solution.hide.html` in two exercises): the reference solution, hidden by the LearnPack interface until you ask for it.
+
+## 🤝 Contributors
+
+20 people have contributed to this repository. Ordered by number of commits:
+
+- [@alesanchezr](https://github.com/alesanchezr) — original author of the tutorial
+- [@josemoracard](https://github.com/josemoracard)
+- [@tommygonzaleza](https://github.com/tommygonzaleza)
+- [@UmiKami](https://github.com/UmiKami)
+- [@Charlytoc](https://github.com/Charlytoc)
+- [@ElviraQDP](https://github.com/ElviraQDP)
+- [@Lorenagubaira](https://github.com/Lorenagubaira)
+
+The full list is on the [contributors graph](https://github.com/4GeeksAcademy/css-layouts-tutorial-exercises/graphs/contributors). This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification, and contributions of any kind are welcome — report problems at the [LearnPack issue tracker](https://github.com/learnpack/learnpack/issues/new).
 <!-- endhide -->


### PR DESCRIPTION
Rewrite of the root README in **both languages**, for clarity, search engines and AI answer engines. No content removed: everything that was there is either still visible or moved inside `<!-- hide -->`.

## Why some sections moved inside `<!-- hide -->`

Everything between those markers is stripped before the README is published on `4geeks.com`, but still shows here on GitHub. The platform already renders its own `h1` and its own stats (skill level, duration) from the database, so repeating them in the body shows up twice and can drift out of sync. Title, badges, the metadata block, install steps, repo layout and contributors now live there.

## What was added to the published part

An opening summary, what you will learn, what you will build (the real exercises, counted), prerequisites, common mistakes taken from the exercise content itself, and an FAQ with one `###` heading per question.

## Two constraints worth knowing

- **No markdown tables in the published part.** The `4geeks.com` renderer has no table extension, so a table shows up there as raw pipes and dashes. Lists are used instead.
- **Code fences inside a numbered list must be indented.** At column 0 they close the list, which splits it into several `<ol>` blocks and restarts the numbering. This was happening and is fixed.

Every link in both files was verified — and on `4geeks.com` specifically by reading the rendered body, because that domain returns HTTP 200 for URLs that do not exist.

Happy to adjust tone, wording or structure. If the direction looks right, the same treatment can be applied to the rest of the exercise repos.
